### PR TITLE
Adding crashlog viewer plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "gemini.koplugin"]
 	path = gemini.koplugin
 	url = https://repo.or.cz/gemini.koplugin.git
+[submodule "crashlog.koplugin"]
+	path = crashlog.koplugin
+	url = https://github.com/billiam/crashlog.koplugin.git


### PR DESCRIPTION
> Simple crash.log viewer for KOReader

## screenshot

![KOReader dialog with a verbose crash.log displayed in a scrollable box. The dialog title reads 'crash.log', containing a close button on the right and a menu button on the left. Below the titlebar is a set of buttons for filtering log entries labeled "All", "Debug", "Info", "Warn" and "Error".](https://github.com/user-attachments/assets/66d37e66-1f03-4065-93a7-d48263741ea1)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/29)
<!-- Reviewable:end -->
