### PR TITLE
Add hardcover.app plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "crashlog.koplugin"]
 	path = crashlog.koplugin
 	url = https://github.com/billiam/crashlog.koplugin.git
+[submodule "hardcoverapp.koplugin"]
+	path = hardcoverapp.koplugin
+	url = https://github.com/billiam/hardcoverapp.koplugin


### PR DESCRIPTION
[`hardcoverapp.koplugin`](https://github.com/koreader/contrib.git) is a plugin to sync reading status, book ratings, and journal entries to [hardcover.app](https://hardcover.app) from koreader.

The plugin is reasonably stable currently and feature complete

## Screenshots

![Hardcover plugin main menu with the following menu items: the currently linked book (Frankenstein), an option to change the edition specific edition, a checkbox to Automatically track progress, Update status (which opens a submenu), Settings (which opens a submenu), and About](https://github.com/user-attachments/assets/0fd8f6fb-3a61-471f-9450-9a0b3dadc9d1)

![A menu to update book status containing: a set of radio buttons for the current book status (Want to read, currently reading, read and did not finish), an item to unset the current status. The following section has an item to update the current page (displaying page 154 of 353), add a note, update rating (displaying the current rating of 4.5 stars), and an item to update the status privacy settings which open in a submenu](https://github.com/user-attachments/assets/55b33a0a-bda8-4ec9-918d-0409266abe3b)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/32)
<!-- Reviewable:end -->
