### PR TITLE
Plugin to add WebDAV to highlights export targets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "hardcoverapp.koplugin"]
 	path = hardcoverapp.koplugin
 	url = https://github.com/billiam/hardcoverapp.koplugin
+[submodule "provider-webdav-highlights.koplugin"]
+	path = provider-webdav-highlights.koplugin
+	url = https://github.com/fairlygood/provider-webdav-highlights.koplugin.git


### PR DESCRIPTION
Adds WebDAV to the available targets for exporting highlights.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/33)
<!-- Reviewable:end -->
