### PR TITLE
Add chess application plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "readingruler.koplugin"]
 	path = readingruler.koplugin
 	url = https://github.com/syakhisk/readingruler.koplugin
+[submodule "kochess.koplugin"]
+	path = kochess.koplugin
+	url = https://github.com/bateast/kochess


### PR DESCRIPTION
Kochess is a simple yet functional chess application designed for Koreader. It allows to play between human being, against a built-in UCI chess engine (like Stockfish), load and save games in PGN format, and review past moves.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/40)
<!-- Reviewable:end -->
