### PR TITLE
Adding airplanemode as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -41,3 +41,6 @@
 [submodule "karmtka.koplugin"]
 	path = karmtka.koplugin
 	url = https://github.com/cyanjnpr/karmtka.koplugin
+[submodule "airplanemode.koplugin"]
+	path = airplanemode.koplugin
+	url = git@github.com:kodermike/airplanemode.koplugin.git


### PR DESCRIPTION
This plugin adds a convenient way to quickly turn off all networking related plugins and disable networking. There are a few defaults that can be easily changed, as well as a menu for changing what is (or isn't) included when turning on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/52)
<!-- Reviewable:end -->
