### PR TITLE
feat: add comicreader.koplugin as a new git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -50,3 +50,6 @@
 [submodule "assistant.koplugin"]
 	path = assistant.koplugin
 	url = https://github.com/omer-faruq/assistant.koplugin
+[submodule "comicreader.koplugin"]
+	path = comicreader.koplugin
+	url = https://github.com/OGKevin/comicreader.koplugin.git


### PR DESCRIPTION
Added comicreader.koplugin to .gitmodules and initialized the submodule with commit ae508f9 (v0.0.2).

Relates-To: https://github.com/OGKevin/comicreader.koplugin/issues/34

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/59)
<!-- Reviewable:end -->
