### PR TITLE
feat: add comicmeta.koplugin submodule for comic metadata

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -50,3 +50,6 @@
 [submodule "assistant.koplugin"]
 	path = assistant.koplugin
 	url = https://github.com/omer-faruq/assistant.koplugin
+[submodule "comicmeta.koplugin"]
+	path = comicmeta.koplugin
+	url = https://github.com/NightQuest/comicmeta.koplugin


### PR DESCRIPTION
Added comicmeta.koplugin as a new submodule to support comic metadata features.

Initialised at b123990 (v1.1)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/60)
<!-- Reviewable:end -->
