### PR TITLE
Add 20-20-20 koreader plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -199,3 +199,6 @@
 [submodule "kotranslate.koplugin"]
 	path = kotranslate.koplugin
 	url = https://github.com/omer-faruq/kotranslate.koplugin
+[submodule "20-20-20.koplugin"]
+	path = 20-20-20.koplugin
+	url = https://github.com/vardan-developer/20-20-20.koplugin.git


### PR DESCRIPTION
A simple KOReader plugin that helps you follow the 20-20-20 eye-rest rule. It runs a background timer while KOReader is open, then shows a fullscreen black rest screen with a large countdown when the timer completes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/129)
<!-- Reviewable:end -->
