### PR TITLE
Add Readeck KOReader plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -208,3 +208,6 @@
 [submodule "zen_ui.koplugin"]
 	path = zen_ui.koplugin
 	url = https://github.com/AnthonyGress/zen_ui.koplugin
+[submodule "readeck.koplugin"]
+	path = readeck.koplugin
+	url = https://github.com/iceyear/readeck.koplugin.git


### PR DESCRIPTION
Adds readeck.koplugin as a KOReader contrib application.

The plugin synchronizes articles from a Readeck server to KOReader and includes README, Chinese README, license.

Submodule source:
https://github.com/iceyear/readeck.koplugin/tree/koreader-contrib

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/133)
<!-- Reviewable:end -->
