### PR TITLE
Add speakword.koplugin (TTS)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -211,3 +211,6 @@
 [submodule "readeck.koplugin"]
 	path = readeck.koplugin
 	url = https://github.com/iceyear/readeck.koplugin.git
+[submodule "speakword.koplugin"]
+	path = speakword.koplugin
+	url = https://github.com/anatoly314/speakword.koplugin.git


### PR DESCRIPTION
Adds `speakword.koplugin` as a submodule.

## What it does
Speaks selected words and sentences via [ElevenLabs](https://elevenlabs.io/) TTS, with a small on-device cache so repeated lookups are instant and free. Triggered from the highlight menu so it integrates with the standard text-selection flow.

## Compatibility
- Works best on Android: audio plays in-process via a bundled MediaPlayer helper, so playback is silent-launch and stays inside KOReader.
- On other platforms it falls back to handing the audio file off to the system via the standard openLink intent.

## License
AGPL-3.0

## Upstream
https://github.com/anatoly314/speakword.koplugin

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/134)
<!-- Reviewable:end -->
