### PR TITLE
Add bookshelf.koplugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -214,3 +214,6 @@
 [submodule "speakword.koplugin"]
 	path = speakword.koplugin
 	url = https://github.com/anatoly314/speakword.koplugin.git
+[submodule "bookshelf.koplugin"]
+	path = bookshelf.koplugin
+	url = https://github.com/AndyHazz/bookshelf.koplugin.git


### PR DESCRIPTION
## Summary

Adds [bookshelf.koplugin](https://github.com/AndyHazz/bookshelf.koplugin) — a full-screen home screen for KOReader.

**Features:**
- Book detail view showing the current book's cover, title, author, series, and progress bar with fully configurable token-based detail lines
- Chip strip with tabs for Home, Recent, Favourites, Series, Authors, Genres, Folders, Tags, and Search views — each with independent sort controls
- Paginated cover grid (3x4 / 2x4) with swipe navigation; swipe up to collapse the detail view and expand the grid
- Search with grouped results across folders, authors, series, genres, and books
- Long-press book menu with Go-to-Author / Go-to-Series / Go-to-Genre navigation
- In-app updater with background update checks
- Full i18n support via gettext (.pot provided)

**Compatibility:** Tested on Kindle Paperwhite 5. Requires KOReader 2024.11+.

**Maintainer:** @AndyHazz

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/136)
<!-- Reviewable:end -->
