### PR TITLE
Sokoban puzzle game plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -217,3 +217,6 @@
 [submodule "bookshelf.koplugin"]
 	path = bookshelf.koplugin
 	url = https://github.com/AndyHazz/bookshelf.koplugin.git
+[submodule "sokoban.koplugin"]
+	path = sokoban.koplugin
+	url = https://github.com/kbarni/sokoban.koplugin


### PR DESCRIPTION
Reimplementation of the classic Sokoban game from 1982 for Koreader. 

Your task is to push the boxes in the warehouse to the target areas. You can only push one box at a time and you can't pull a box. The challenge is planning moves correctly to avoid causing a deadlock, a situation where a box or the player becomes permanently trapped, making the puzzle unsolvable. 

The game contains over 450 levels in 5 level sets (and a level converter to add other level sets).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/137)
<!-- Reviewable:end -->
