### PR TITLE
Frotz - Interactive fiction interpreter for Koreader

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -227,3 +227,6 @@
 	path = dynamicxray.koplugin
 	url = https://github.com/smartscripts-nl/dynamic-xray
 	branch = main
+[submodule "frotz.koplugin"]
+	path = frotz.koplugin
+	url = https://github.com/kbarni/frotz.koplugin


### PR DESCRIPTION
Frotz.plugin allows users to play interactive fiction games directly from Koreader.

Depends on the dfrotz binary, provided for different architectures.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/141)
<!-- Reviewable:end -->
