### PR TITLE
Add Acorny highlight sync plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -230,3 +230,6 @@
 [submodule "frotz.koplugin"]
 	path = frotz.koplugin
 	url = https://github.com/kbarni/frotz.koplugin
+[submodule "provider-acorny-highlights.koplugin"]
+	path = provider-acorny-highlights.koplugin
+	url = https://github.com/momadacoding/provider-acorny-highlights.koplugin.git


### PR DESCRIPTION
Adds provider-acorny-highlights.koplugin as a contrib submodule pointing to the standalone Acorny highlight sync plugin repository.

Plugin repository:
- https://github.com/momadacoding/provider-acorny-highlights.koplugin

The plugin registers Acorny in the Export highlights provider list, supports manual export, and can automatically queue/sync newly created highlights when KOReader has network access. The plugin repository includes a minimal README with install, token setup, and test instructions.

Tests run in the plugin repository:
- lua spec\acorny_spec.lua
- lua syntax load checks for main.lua, acorny.lua, acorny_helper.lua, and _meta.lua

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/142)
<!-- Reviewable:end -->
