### PR TITLE
Add wireguard.koplugin as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -233,3 +233,6 @@
 [submodule "provider-acorny-highlights.koplugin"]
 	path = provider-acorny-highlights.koplugin
 	url = https://github.com/momadacoding/provider-acorny-highlights.koplugin.git
+[submodule "wireguard.koplugin"]
+	path = wireguard.koplugin
+	url = https://github.com/wtb04/wireguard.koplugin.git


### PR DESCRIPTION
Wrapper plugin to enable Wireguard VPN connection for KOReader.

Only tested on Kobo Clara Colour.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/143)
<!-- Reviewable:end -->
