### PR TITLE
Add backlog.koplugin as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -236,3 +236,6 @@
 [submodule "wireguard.koplugin"]
 	path = wireguard.koplugin
 	url = https://github.com/wtb04/wireguard.koplugin.git
+[submodule "backlog.koplugin"]
+	path = backlog.koplugin
+	url = https://github.com/cdrso/backlog.koplugin.git


### PR DESCRIPTION
Adds [backlog.koplugin](https://github.com/cdrso/backlog.koplugin) as a submodule.

Per-chapter read tracking for anthology EPUBs in KOReader — marks individual articles/chapters read as you page through a collection, fades links to already-read entries, and groups progress by section for nested TOCs.

- README and LICENSE included in the repo.
- Maintained by @cdrso.

Requested in cdrso/backlog.koplugin#3.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/144)
<!-- Reviewable:end -->
