### PR TITLE
Add lingueez.koplugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -239,3 +239,6 @@
 [submodule "backlog.koplugin"]
 	path = backlog.koplugin
 	url = https://github.com/cdrso/backlog.koplugin.git
+[submodule "lingueez.koplugin"]
+	path = lingueez.koplugin
+	url = https://github.com/lysak-yurii/lingueez.koplugin.git


### PR DESCRIPTION
Adds **lingueez.koplugin** as a submodule.

Lingueez lets you save words straight from your e-reader into your [Lingueez](https://lingueez.app) vocabulary — long-press a word and tap **Save to Lingueez**: the plugin detects the language, translates it (Google Translate built in, optional DeepL), and syncs it to your account on the desktop and web apps.

**Features**
- Quick-save any word while reading, without leaving the book
- Review saved words with flashcards directly on the reader
- Automatic source-language detection from the book
- Save whole chapters/texts to your Lingueez library and download them back to the reader
- Email or QR-based Google sign-in

A README with installation, sign-in and usage instructions is included in the plugin folder.

Repo: https://github.com/lysak-yurii/lingueez.koplugin

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/145)
<!-- Reviewable:end -->
