### PR TITLE
Add koreader-mosh client application

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -245,3 +245,6 @@
 [submodule "luminaria.koplugin"]
 	path = luminaria.koplugin
 	url = https://github.com/jamesisonfire21-glitch/luminaria-koreader-plugin.git
+[submodule "koreader-mosh"]
+	path = koreader-mosh
+	url = https://github.com/jnordlund/koreader-mosh.git


### PR DESCRIPTION
## Summary

Mosh, the mobile shell, is a remote terminal protocol designed for unstable
network connections. It starts over SSH, then keeps an encrypted UDP session
alive while the client changes networks, loses connectivity, or goes to sleep.
Unlike a normal SSH terminal, a Mosh session can recover without
re-authenticating after the connection comes back.

This is useful on e-ink readers because Wi-Fi is often intermittent, devices
sleep aggressively to save battery, and terminal input is slower than on a
laptop. With Mosh, a KOReader terminal session can be hidden, the Kobo can sleep
and wake, and the user can continue the same remote shell after Wi-Fi returns,
without retyping credentials or restarting the workflow.

This PR adds `koreader-mosh` as a standalone contrib app submodule.
`koreader-mosh` provides client-only Mosh support for KOReader's terminal on
Kobo. It packages a Lua plugin, a native launcher, the Kobo `mosh-client`
binary, a local `vt52` terminfo entry, tests, package validation, and Kobo
packaging CI.

## Behavior

- This is client-only Mosh support for KOReader's terminal on Kobo.
- The remote host must provide `mosh-server`.
- The selected Mosh UDP port or port range must be reachable through the remote
  firewall.
- KOReader does not gain an SSH server, a Mosh server, host profiles, or
  automatic key management.
- SSH authentication, host-key prompts, and key handling stay delegated to
  KOReader's bundled Dropbear `dbclient`.
- After startup, the launcher is replaced by `mosh-client`, so a running Mosh
  session can survive KOReader terminal Close/reopen as long as KOReader and the
  local client process keep running.

## Validation

- App repository commit:
  `dd6bfd3787a3b7e8c924aef331f71dcc5b2d5dc0`
- Contrib submodule commit:
  `dd6bfd3787a3b7e8c924aef331f71dcc5b2d5dc0`
- GitHub Actions run:
  <https://github.com/jnordlund/koreader-mosh/actions/runs/28731573129>
- Kobo package artifact:
  `koreader-mosh-0.1.0-kobo.zip`
- Kobo package SHA-256:
  `8e9e17cbee3de01ea5b5ea61fd4e888b62241fff3e8f2e1b07682a012523bf0e`

Automated validation:

- `make test`
- launcher unit tests
- package validation
- Kobo package build in GitHub Actions

Physical validation:

- Device model: Kobo Clara Colour
- KOReader version: not recorded
- `mosh user@host` starts a remote Mosh session from KOReader's terminal.
- Host-key acceptance and both password-based and key-based login paths were
  exercised through the launcher/`dbclient` startup flow.
- Closing and reopening KOReader's terminal returns to the same running Mosh
  session.
- Kobo sleep/wake plus Wi-Fi reconnection resumes the same Mosh session without
  new SSH authentication.

## Scope

Initial support is Kobo-only. The app repository documents compatibility,
security notes, troubleshooting, architecture, and the physical device checklist.
This PR only adds the contrib submodule entry and gitlink.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/147)
<!-- Reviewable:end -->
