### PR TITLE
Add wifiindicator.koplugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -251,3 +251,7 @@
 [submodule "readinginsights.koplugin"]
 	path = readinginsights.koplugin
 	url = https://github.com/peterboda236/readinginsights.koplugin.git
+[submodule "wifiindicator.koplugin"]
+	path = wifiindicator.koplugin
+	url = https://github.com/asxelot/wifiindicator.koplugin.git
+	branch = main


### PR DESCRIPTION
Adds [wifiindicator.koplugin](https://github.com/asxelot/wifiindicator.koplugin) as a submodule (requested in [asxelot/wifiindicator.koplugin#1](https://github.com/asxelot/wifiindicator.koplugin/issues/1)).

The plugin replaces KOReader's Wi-Fi connection popups ("Scanning for networks…", "Connecting to network X…", …) with a small transient corner icon, and adds a tappable Wi-Fi status icon to the menu bar footer. All three behaviors can be toggled individually under Menu → Network. Matching is done against the gettext-resolved NetworkMgr source strings, so it works in any UI language and needs no device-specific code.

The repo has a README with install instructions and a stub-based regression test suite. I maintain it and will keep it working against KOReader releases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/150)
<!-- Reviewable:end -->
