### PR TITLE
Add excludehistory.koplugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -261,3 +261,6 @@
 [submodule "bluetooth.koplugin"]
 	path = bluetooth.koplugin
 	url = https://github.com/linsyking/bluetooth.koplugin.git
+[submodule "excludehistory.koplugin"]
+	path = excludehistory.koplugin
+	url = https://github.com/jperon/excludehistory.koplugin.git


### PR DESCRIPTION
Adds `excludehistory.koplugin` as a submodule.

This plugin lets you exclude files or folders from the reading history: long-press a file or folder in the file manager (or in the History screen) and choose "Exclude from history" to remove it and prevent it from being added back. Advanced patterns can be managed manually from More tools → Exclude from history.

Repository: https://github.com/jperon/excludehistory.koplugin

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/155)
<!-- Reviewable:end -->
