### PR TITLE
Add sendtodiscord.koplugin submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -264,3 +264,6 @@
 [submodule "excludehistory.koplugin"]
 	path = excludehistory.koplugin
 	url = https://github.com/jperon/excludehistory.koplugin.git
+[submodule "sendtodiscord.koplugin"]
+	path = sendtodiscord.koplugin
+	url = https://github.com/Intedai/sendtodiscord.koplugin.git


### PR DESCRIPTION
Adds `sendtodiscord.koplugin` as a submodule.

This plugin lets you send highlighted text and text from your clipboard to Discord using webhooks.

Repo: https://github.com/Intedai/sendtodiscord.koplugin/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/156)
<!-- Reviewable:end -->
