### PR TITLE
Add folderlock.koplugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -270,3 +270,6 @@
 [submodule "neodb.koplugin"]
 	path = neodb.koplugin
 	url = https://github.com/neodb-social/neodb.koplugin.git
+[submodule "folderlock.koplugin"]
+	path = folderlock.koplugin
+	url = https://github.com/danieldecesaro/koreader-folderlock.git


### PR DESCRIPTION
Adds [folderlock.koplugin](https://github.com/danieldecesaro/koreader-folderlock) as a
submodule, pinned at [v1.0.0](https://github.com/danieldecesaro/koreader-folderlock/releases/tag/v1.0.0).

## What it does

Asks for a PIN before opening a protected folder or any document inside it. You long-press a
folder in the file manager and choose **Protect with PIN**; after that, entering the folder or
opening any book in it asks for the PIN. An unlock lasts only while you stay inside the
folder, and sleeping re-locks it — waking up asks again and then returns you to the book at
the same page. On the sleep screen the cover of a protected book is replaced by one of
KOReader's default backgrounds, so the lock screen does not give away what you were reading.
Both sleep-related behaviours are switchable and default to on.

## How it relates to screenlockpin.koplugin

They solve different problems and work fine side by side: `screenlockpin` gates the whole
application on wake-up or boot, while this one is per-folder — the rest of your library stays
directly accessible.

## Scope, stated plainly

This is not encryption, and the README says so in its own section. It keeps a curious person
holding the device out of a folder; it does not resist anyone with file access. The files stay
readable over USB, SSH or another reader app, the PIN hash and the folder list live in a plain
settings file on the device, there is no attempt limit, and titles of protected books can
still surface in History, Collections and reading statistics. The PIN itself is stored as
`sha256(salt .. pin)` with a random per-install salt, never in clear text.

## Checklist against the contributing notes

- **Git submodule pointing upstream** — yes, HTTPS URL, pinned at the `v1.0.0` tag.
- **README** — yes, covering install, usage, the limits above, the implementation, and how to
  add a translation.
- **Compatibility** — in the README's *Requirements* section: needs
  `FileManager:addFileDialogButtons`, `ffi/sha2` and `WidgetContainer:extend`. Tested against
  **KOReader v2026.07** on a Kindle 10th generation (`KindleBasic3`, 600x800 @ 167 dpi) and on
  the SDL emulator at the same geometry. No device-specific code: everything goes through
  `Device:has*()` and `Screen:scaleBySize()`, so it should behave on Kobo, PocketBook and
  Android, but I have not been able to test those.
- **License** — AGPL-3.0, matching KOReader and this repository.
- **It works** — verified on the device, not only in the emulator.
- **Maintenance** — mine; issues on the upstream repository.

## Implementation note, in case it is useful for review

Access is gated at five points rather than one, since a folder lock is only worth the number
of ways around it: `FileChooser.changeToPath` (tapping in, shortcuts, go-to-folder, search),
`ReaderUI.showReader` (History, Collections, file searcher, open-last-file), the `PathChanged`
event (file manager *built* at a protected `lastdir`, which never passes through
`changeToPath`), plugin `init` in reader context (document resumed before the plugin exists),
and `Screensaver.setup`/`close` for sleep and wake. That last pair is deliberate: on Kindle
the power path calls `Screensaver:setup()` directly and never broadcasts a `Suspend` event, so
an `onSuspend` handler never runs on the device. Class methods are wrapped following the
`coverbrowser.koplugin` idiom — originals kept in locals, patched once, guarded against
re-patching.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/159)
<!-- Reviewable:end -->
