### PR TITLE
Add offlinetranslate-koplugin: offline phrase translation with a local NMT server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -285,3 +285,6 @@
 [submodule "crossword-omerfaruq.koplugin"]
 	path = crossword-omerfaruq.koplugin
 	url = https://github.com/omer-faruq/crossword.koplugin
+[submodule "offlinetranslate-koplugin"]
+	path = offlinetranslate-koplugin
+	url = https://github.com/fundacja-reborn/offlinetranslate-koplugin.git


### PR DESCRIPTION
Adds [offlinetranslate-koplugin](https://github.com/fundacja-reborn/offlinetranslate-koplugin) as a submodule, following Frenzie's suggestion in koreader/koreader#15838.

**What it does.** Translates a dragged selection with a neural machine translation server running on the device, and shows the result in a bubble anchored over the selection. Single words stay with the built-in StarDict dictionaries - a long press never reaches the plugin. Phrases you translate, and words you look up in a dictionary, get a faint dotted underline wherever they turn up again, in every book. That is the point of it: it is built for reading in a language you are still learning, where meeting an expression again is the part that does the work.

**What it needs.** A server answering the LibreTranslate API on `127.0.0.1` - [Translator](https://github.com/DavidVentura/offline-translator) on Android, from F-Droid, or LibreTranslate on a desktop. It only ever talks to loopback, so it makes no use of `NetworkMgr` and never asks to turn on Wi-Fi.

Against the requirements in your README:

- **Works when merging** - released, currently v0.6.0, in daily use on an Onyx Boox Page.
- **README** - what it does, install, configuration, and a **Compatibility** section naming what is tested, what should work, and where there is no on-device server for it to talk to (Kobo, Kindle, PocketBook).
- **Not work in progress, not deprecated.**
- **AGPL-3.0-or-later**, the same license as KOReader.
- Pure Lua, no binaries, and nothing beyond what KOReader already ships.

**One thing to flag about the submodule path.** The repository root is the project rather than the plugin directory - the plugin lives in `offlinetranslate.koplugin/`, next to tests, tooling and a vendored copy of the KOReader sources I check the API against. Frenzie said that layout is fine in the discussion. I named the path after the repository instead of `offlinetranslate.koplugin` because a directory carrying that name which cannot be copied straight into `plugins/` seemed more misleading than one that is plainly the project. Happy to rename it if you would rather keep the convention.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/162)
<!-- Reviewable:end -->
