### PR TITLE
Add kocatchup.koplugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -288,3 +288,6 @@
 [submodule "offlinetranslate-koplugin"]
 	path = offlinetranslate-koplugin
 	url = https://github.com/fundacja-reborn/offlinetranslate-koplugin.git
+[submodule "kocatchup.koplugin"]
+	path = kocatchup.koplugin
+	url = https://github.com/paulbockewitz/kocatchup.koplugin.git


### PR DESCRIPTION
Adds [kocatchup.koplugin](https://github.com/paulbockewitz/kocatchup.koplugin) — spoiler-safe AI "story so far" recaps for the book you're reading, strictly bounded to your current position (only pre-position text is ever sent to the model). KOReader's answer to Kindle's "Story So Far" feature.

- Works with any OpenAI-compatible endpoint (OpenAI, OpenRouter, Groq, local Ollama) or Anthropic; the user supplies their own API key.
- Rolling incremental recap updates, optional background pre-generation, and optional catch-up offers after a reading break.
- Optional in-app updater (verified TLS only, sha256-checked against the release digest, validate-before-swap).
- GPL-3.0, README with per-device install instructions, and a COMPATIBILITY file (developed against 2026.x; verified on Kindle and the desktop emulator).
- 115-spec test suite runs on stock LuaJIT; releases are CI-built with tag/version enforcement.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/163)
<!-- Reviewable:end -->
