### PR TITLE
Add kindlebtcontroller.koplugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -291,3 +291,6 @@
 [submodule "kocatchup.koplugin"]
 	path = kocatchup.koplugin
 	url = https://github.com/paulbockewitz/kocatchup.koplugin.git
+[submodule "kindlebtcontroller.koplugin"]
+	path = kindlebtcontroller.koplugin
+	url = https://github.com/finlater/kindlebtcontroller.koplugin.git


### PR DESCRIPTION
## What changed

Adds [kindlebtcontroller.koplugin](https://github.com/finlater/kindlebtcontroller.koplugin) as a git submodule.

## Why

The plugin lets Bluetooth game controllers and remote controllers control KOReader on supported Kindle devices, including page turning, brightness and warmth adjustment, chapter navigation, configurable key mappings, and automatic reconnection.

## Compatibility

The upstream README documents setup requirements and safety warnings. The plugin has been verified on Kindle 2024, Kindle Paperwhite 11, and Kindle Paperwhite 12. It is Kindle-only and requires a classic Bluetooth HID controller; BLE is not supported.

## Validation

- Confirmed the submodule URL points to `finlater/kindlebtcontroller.koplugin`.
- Confirmed the referenced repository contains `README.md` and `LICENSE`.
- Confirmed all Lua files parse successfully with `luac -p`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/164)
<!-- Reviewable:end -->
