### PR TITLE
Add Swipe_Animation.koplugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -297,3 +297,6 @@
 [submodule "linefocus.koplugin"]
 	path = linefocus.koplugin
 	url = https://github.com/Fiddelis/linefocus.koplugin
+[submodule "Swipe_Animation.koplugin"]
+	path = Swipe_Animation.koplugin
+	url = https://github.com/koplugin-swipe-animation/Swipe_Animation.koplugin


### PR DESCRIPTION
Adds [Swipe_Animation.koplugin](https://github.com/koplugin-swipe-animation/Swipe_Animation.koplugin) as a submodule.

Software wipe page-turn animation for Linux e-ink KOReader (not Android). It is a `frontend/` + `patches/` overlay, not a drop-in `plugins/` module — install steps are in the upstream README.

GPLv3. Requires KOReader 2026.07.1+.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/166)
<!-- Reviewable:end -->
