### PR TITLE
Add sudokuplus.koplugin submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -300,3 +300,6 @@
 [submodule "Swipe_Animation.koplugin"]
 	path = Swipe_Animation.koplugin
 	url = https://github.com/koplugin-swipe-animation/Swipe_Animation.koplugin
+[submodule "sudokuplus.koplugin"]
+	path = sudokuplus.koplugin
+	url = https://github.com/Borisvl/sudokuplus.koplugin.git


### PR DESCRIPTION
### Sudoku+ for KOReader (`sudokuplus.koplugin`)

A logical Sudoku puzzle game and interactive tutor crafted specifically for e-ink readers running KOReader.
- **Upstream Repository**: https://github.com/Borisvl/sudokuplus.koplugin
- **Version**: 1.1.0
- **License**: AGPL-3.0
- **Features**:
  - 17 human deductive technique families (from Naked Singles to AIC chains
  - 6 exact difficulty tiers & custom strategy practice mode
  - Unlimited on device puzzle generation
  - 3-stage hint tutor (Identify -> Highlight -> Apply) and full notes support
  - Full game history, analytics, stats, and seed-sharing system
  - E-ink optimized partial refreshes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/167)
<!-- Reviewable:end -->
