### PR TITLE
Add resumemarker.koplugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -303,3 +303,6 @@
 [submodule "sudokuplus.koplugin"]
 	path = sudokuplus.koplugin
 	url = https://github.com/Borisvl/sudokuplus.koplugin.git
+[submodule "resumemarker.koplugin"]
+	path = resumemarker.koplugin
+	url = https://github.com/birosrichard/resumemarker.koplugin.git


### PR DESCRIPTION
## Summary
- add `birosrichard/resumemarker.koplugin` as a contrib submodule
- provide one persistent, private resume marker per reflowable book
- support setting the marker from selection and dictionary popups without creating bookmarks, highlights, notes, or annotations

## Validation
- [x] manually tested on Kobo with KOReader v2026.03
- [x] verified against KOReader v2026.03 plugin APIs
- [x] parsed Lua sources successfully
- [x] confirmed the upstream repository includes user documentation and an MIT license


Made with [Cursor](https://cursor.com)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/168)
<!-- Reviewable:end -->
