### PR TITLE
Add unitlens.koplugin submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -306,3 +306,6 @@
 [submodule "resumemarker.koplugin"]
 	path = resumemarker.koplugin
 	url = https://github.com/birosrichard/resumemarker.koplugin.git
+[submodule "unitlens.koplugin"]
+	path = unitlens.koplugin
+	url = https://github.com/farengeyt451/unitlens.koplugin


### PR DESCRIPTION
Adds **unitlens.koplugin** as a submodule.

#### Overview
This plugin provides a reference for units of measurement, allowing you to see the equivalent unit in another measurement system. 

#### Features

- **Offline:** No network, no AI. All data ships in the plugin
- **Dictionary-driven:** Every conversion is a precomputed string in a per-language
  dictionary
- **Configurable UI:** configurable underline, font and tooltip
- **Per-book language, translatable interface:** Book language auto-detects from
  metadata (with a manual override remembered per book); the menu itself ships in
  Russian, English and Spanish
- **User-extensible.** Drop a new `dicts/<code>.lua` in and it's discovered
  automatically - no code changes

**Repository:** https://github.com/farengeyt451/unitlens.koplugin

#### Validation & Compatibility

Tested on **Pocketbook Era Lite** • KOReader **2026.03** and **2026.07**

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/169)
<!-- Reviewable:end -->
