### PR TITLE
Add MRI plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -306,3 +306,7 @@
 [submodule "resumemarker.koplugin"]
 	path = resumemarker.koplugin
 	url = https://github.com/birosrichard/resumemarker.koplugin.git
+[submodule "mri.koplugin"]
+	path = mri.koplugin
+	url = https://github.com/frankshiii/mri.git
+	branch = koreader-contrib


### PR DESCRIPTION
## Summary

Adds MRI, a spoiler-aware EPUB reading assistant for KOReader on Kindle.

MRI can recap the current chapter or earlier reading, explain selected people, places, concepts, and passages, build cached reference lists, and answer questions within the current reading boundary.

## Upstream

- Repository: https://github.com/frankshiii/mri
- Release: https://github.com/frankshiii/mri/releases/tag/v0.1.0
- Plugin branch: https://github.com/frankshiii/mri/tree/koreader-contrib

## Compatibility and testing

- EPUB only; PDF is currently out of scope.
- Compatibility baseline: KOReader v2025.08.
- Manually tested on a physical Kindle: the plugin loads, EPUB books open normally, the About page renders, and an MRI API query completes.
- The upstream project also runs Lua parsing, JSON validation, credential checks, and package generation in GitHub Actions.

## Privacy and maintenance

- API keys are supplied by the user and stored locally; no key is included in this submodule.
- Spoiler protection is enabled by default.
- Temporary conversations remain session-only. Per-book recaps and caches use KOReader book settings.
- The upstream repository includes bilingual documentation, compatibility notes, an AGPL-3.0-or-later licence, and a maintained release workflow.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/170)
<!-- Reviewable:end -->
