### PR TITLE
Add charart.koplugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -310,3 +310,6 @@
 	path = mri.koplugin
 	url = https://github.com/frankshiii/mri.git
 	branch = koreader-contrib
+[submodule "charart.koplugin"]
+	path = charart.koplugin
+	url = https://github.com/afzafri/charart.koplugin.git


### PR DESCRIPTION
Adds **Character Art**, a plugin for looking up pictures of a character while reading.

Highlight a character's name and the plugin searches the book's wiki for art of
them, showing it in KOReader's image viewer with the artist credited. It is
reachable from the dictionary popup, the highlight menu, or a bindable gesture.

The lookup resolves the highlighted text to a wiki article before looking for
pictures, which keeps results sane when a reader highlights a long or
half-remembered name rather than a bare one.

- Repository: https://github.com/afzafri/charart.koplugin
- Licence: MIT
- No API keys, no accounts, no AI services. It talks only to the book's wiki
  and that wiki's image host.

Any MediaWiki site works, so it is not limited to Fandom; independent wikis can
be used by pasting their address.

**Compatibility.** Developed and tested on an Onyx BOOX Go 6 running KOReader
v2026.07.1 on Android 11. It uses only KOReader APIs and no device-specific
features, so it should work wherever KOReader runs, but Kobo, Kindle and
desktop are untested. There is a compatibility section in the README.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/171)
<!-- Reviewable:end -->
