### PR TITLE
Add Leading Manga Zoom plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -322,3 +322,7 @@
 [submodule "dual_wiki.koplugin"]
 	path = dual_wiki.koplugin
 	url = https://github.com/YeYinYing/koreader-dual-wiki.git
+[submodule "leadingmangazoom.koplugin"]
+	path = leadingmangazoom.koplugin
+	url = https://github.com/Auri3l/leadingmangazoom.koplugin.git
+	branch = koreader-contrib


### PR DESCRIPTION
Adds [Leading Manga Zoom](https://github.com/Auri3l/leadingmangazoom.koplugin) as an upstream Git submodule for reading manga and comics.

The plugin provides two-finger quadrant zoom, spread/pinch zoom, RTL support, automatic landscape rotation, and split-spread navigation using touch gestures or physical page-turn buttons. It is maintained by Auri3l and forked from Maximum by Shac0x, with attribution retained.

The submodule is pinned to `ec7c31a91a861ef83feda3f0ebbf45793a67f798` on the upstream `koreader-contrib` branch. This branch places the installable plugin at the repository root; all seven Lua files are byte-for-byte identical to [v1.1.2](https://github.com/Auri3l/leadingmangazoom.koplugin/releases/tag/v1.1.2). It also includes installation instructions, compatibility notes, upstream support links, and the GPL-3.0 license.

Compatibility: fixed-layout CBZ, CBR, CBT, CB7, CZB and PDF documents with Reflow disabled. Zoom gestures require multi-touch. Maximum can remain installed, but overlapping gesture features should be enabled in only one plugin at a time.

Validation: LuaJIT syntax and the submodule layout were checked. Upstream v1.1.2 CI passes Lua 5.1/LuaJIT regression tests and integration tests using the real touch-dispatch modules from KOReader 2026.03 and 2026.07. Physical-device testing of v1.1.2 was not available; no hardware-validation claim is made.

Bug reports and maintenance remain in the [upstream issue tracker](https://github.com/Auri3l/leadingmangazoom.koplugin/issues).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/178)
<!-- Reviewable:end -->
