### PR TITLE
Add Suwayomi Client plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -335,3 +335,6 @@
 [submodule "storefront.koplugin"]
 	path = storefront.koplugin
 	url = https://github.com/ultimatejimmy/storefront.koplugin.git
+[submodule "suwayomi.koplugin"]
+	path = suwayomi.koplugin
+	url = https://github.com/LK4D4/suwayomi.koplugin.git


### PR DESCRIPTION
Adds Suwayomi Client as a Git submodule, pinned to v1.1.1
(0bd85fe905a91c01c5ba0aab4fc415c45e72cff8).

The plugin lets users browse their Suwayomi library and sources,
download chapters as device-local CBZ files for offline reading,
and sync read/unread state with their server.

Requires a Suwayomi server reachable from the KOReader device.
The plugin does not manage the server's download queue.

- Repository and installation: https://github.com/LK4D4/suwayomi.koplugin
- Release: https://github.com/LK4D4/suwayomi.koplugin/releases/tag/v1.1.1
- Support: https://github.com/LK4D4/suwayomi.koplugin/issues
- Related request: https://github.com/LK4D4/suwayomi.koplugin/issues/32

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/contrib/180)
<!-- Reviewable:end -->
